### PR TITLE
Rename postinstall script to "start"

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
     "webpack": "^1.13.1"
   },
   "scripts": {
-    "postinstall": "webpack --watch"
+    "start": "webpack --watch"
   }
 }


### PR DESCRIPTION
Otherwise Webpack will start when this dependency is included, and nothing will be added to the projects package.json file.